### PR TITLE
fix fetch on add project page

### DIFF
--- a/assets/js/custom/add-project-form.js
+++ b/assets/js/custom/add-project-form.js
@@ -1,3 +1,6 @@
+---
+---
+
 const initializeForm = () => {
   const form = $("#add-project-form");
   form.validate({
@@ -67,7 +70,7 @@ const setProjectFile = file => {
 };
 
 
-fetch('/tags.json')
+fetch('{{site.baseurl}}/tags.json')
   .then(response => response.json())
   .then(tags => {
     initializeForm(); // need to set up query-steps before selectize, otherwise it will wipe out the tag options


### PR DESCRIPTION
## Task

Add Project Page was failing because tag fetching wasn't working.

## Solution

Add front matter and make the `fetch` reference an absolute url based on `site.baseurl`. Solution courtesy of @d3netxer 

## Screenshots

