### PR TITLE
Osm username instead of email

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sweetalert2@8"></script>
 <script type="text/javascript" src="{{site.baseurl}}/assets/js/selectize.min.js"></script>
 <script type="text/javascript" src="{{site.baseurl}}/assets/js/jquery.validate.min.js"></script>
+<script src="{{site.baseurl}}/assets/js/fullcalendar/dist/moment.js"></script>
 <script type="text/javascript" src="{{site.baseurl}}/assets/js/jquery.steps.min.js"></script>
 <script type="text/javascript" src="{{site.baseurl}}/assets/js/custom/add-project-form.js"></script>
 <script type="text/javascript" src="https://unpkg.com/axios/dist/axios.min.js"></script>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -91,7 +91,7 @@
         <p class="project-description">{{ page.description }}</p>
         <div class="project-buttons">
           <a class="primary-button" href="{{ site.baseurl }}/projects">Back to Projects</a>
-          <a class="primary-button" href="https://teachosm-project-content.s3.amazonaws.com/{{ page.filename }}" download="{{ page.url }}">Download Project</a>
+          <a class="primary-button" href="https://teachosm-project-content.s3.amazonaws.com/{{ page.filename }}">Download Project</a>
         </div>
       </content>
     </div>

--- a/assets/js/custom/add-project-form.js
+++ b/assets/js/custom/add-project-form.js
@@ -107,7 +107,7 @@ const projectFileUploadURL = 'https://ohwy7x30i8.execute-api.us-east-1.amazonaws
 const pullRequestURL = 'https://p3keskibu8.execute-api.us-east-1.amazonaws.com/dev/posts';
 
 const submitForm = async () => {
-  const now = Date.now();
+  const now = moment().format('YYYY-MM-DD');
   let imageResponse, imageUploadResponse;
   let fileResponse, fileUploadResponse;
   Swal.fire({

--- a/assets/js/custom/add-project-form.js
+++ b/assets/js/custom/add-project-form.js
@@ -6,8 +6,8 @@ const initializeForm = () => {
   form.validate({
     errorPlacement: (error, element) => element.before(error),
     rules: {
-      confirmEmail: {
-        equalTo: "#email",
+      confirmOSMUsername: {
+        equalTo: "#osmUsername",
       },
       projectImage: {
         required: true,
@@ -48,8 +48,8 @@ const initializeForm = () => {
 let name;
 const setName = value => name = value;
 
-let email;
-const setEmail = value => email = value;
+let osmUsername;
+const setOSMUsername = value => osmUsername = value;
 
 let title;
 const setTitle = value => title = value;
@@ -169,7 +169,7 @@ const submitForm = async () => {
       description,
       difficulty,
       date_posted: now,
-      email,
+      osm_username: osmUsername,
       filename: projectFileName,
       group: '',
       layout: 'project',
@@ -224,7 +224,7 @@ fetch('{{site.baseurl}}/tags.json')
     });
 
     const nameSelector = $('#name');
-    const emailSelector = $('#email');
+    const osmUsernameSelector = $('#osmUsername');
     const titleSelector = $('#projectTitle');
     const subtitleSelector = $('#projectSubtitle');
     const descriptionSelector = $('#projectDescription');
@@ -238,7 +238,7 @@ fetch('{{site.baseurl}}/tags.json')
     const typeSelector = $('.type-filter');
 
     nameSelector.on('change', event => setName(event.target.value));
-    emailSelector.on('change', event => setEmail(event.target.value));
+    osmUsernameSelector.on('change', event => setOSMUsername(event.target.value));
     titleSelector.on('change', event => setTitle(event.target.value));
     subtitleSelector.on('change', event => setSubtitle(event.target.value));
     descriptionSelector.on('change', event => setDescription(event.target.value));

--- a/assets/js/custom/add-project-form.js
+++ b/assets/js/custom/add-project-form.js
@@ -106,6 +106,11 @@ const projectImageUploadURL = 'https://ohwy7x30i8.execute-api.us-east-1.amazonaw
 const projectFileUploadURL = 'https://ohwy7x30i8.execute-api.us-east-1.amazonaws.com/dev/requestUploadURL_content';
 const pullRequestURL = 'https://p3keskibu8.execute-api.us-east-1.amazonaws.com/dev/posts';
 
+const pdfFileName = fileName => {
+  const noExtension = fileName.substring(0, fileName.lastIndexOf('.'));
+  return `${noExtension}.pdf`;
+};
+
 const submitForm = async () => {
   const now = moment().format('YYYY-MM-DD');
   let imageResponse, imageUploadResponse;
@@ -170,7 +175,7 @@ const submitForm = async () => {
       difficulty,
       date_posted: now,
       osm_username: osmUsername,
-      filename: projectFileName,
+      filename: pdfFileName(projectFileName),
       group: '',
       layout: 'project',
       preparation_time: preparationTime,

--- a/assets/js/custom/add-project-form.js
+++ b/assets/js/custom/add-project-form.js
@@ -233,8 +233,8 @@ fetch('{{site.baseurl}}/tags.json')
 
     const audienceSelector = $('.audience-filter');
     const difficultySelector = $('.difficulty-filter');
-    const preparationTimeSelector = $('.preparation-time-filter');
-    const projectTimeSelector = $('.project-time-filter');
+    const preparationTimeSelector = $('.preparation_time-filter');
+    const projectTimeSelector = $('.project_time-filter');
     const typeSelector = $('.type-filter');
 
     nameSelector.on('change', event => setName(event.target.value));

--- a/pages/add-project.html
+++ b/pages/add-project.html
@@ -15,10 +15,10 @@ layout: default
       <p>Welcome to the Create Project form. This form was built to make it easy for contributors to add new projects to the TeachOSM projects portal. Please start by answering a couple questions about yourself.</p>
       <label for="name">What is your name? (The name entered here will show up as the author of the project) *</label>
       <input id="name" name="name" type="text" class="required">
-      <label for="email">What is your email address? *</label>
-      <input id="email" name="email" type="text" class="required email">
-      <label for="confirmEmail">Please confirm your email address *</label>
-      <input id="confirmEmail" name="confirmEmail" type="text" class="required email">
+      <label for="osmUsername">What is your OSM username? *</label>
+      <input id="osmUsername" name="osmUsername" type="text" class="required">
+      <label for="confirmOSMUsername">Please confirm your OSM username *</label>
+      <input id="confirmOSMUsername" name="confirmOSMUsername" type="text" class="required">
     </section>
     <h1>Project Information</h1>
     <section>

--- a/pages/add-project.html
+++ b/pages/add-project.html
@@ -29,18 +29,18 @@ layout: default
       <input id="projectSubtitle" name="projectSubtitle" type="text">
       <label for="projectDescription">Please provide a brief description of the project. *</label>
       <textarea id="projectDescription" name="projectDescription" class="required"></textarea>
-      <label class="top-margin">Please upload a project image. (This will appear beside your project on the site) *</label>
+      <label class="top-margin">Please upload a project image. (This will appear beside your project on the site and should be a .png, .jpg, or .tif file) *</label>
       <br />
       <label style="font-style: italic;">You can either drag and drop an image or click on the "Upload Image" box below</label>
       <div class="uploadable">
-        <input id="projectImage" name="projectImage" type="file" class="required" />
+        <input id="projectImage" name="projectImage" type="file" accept="image/*" class="required" />
         <label id="projectImageLabel" for="projectImage"><i class="fa fa-image"></i><br />Upload Image</label>
       </div>
-      <label class="top-margin">Please upload your project materials. (This is the main content that users will download to help teach the course)*</label>
+      <label class="top-margin">Please upload your project materials. (This is the main content that users will download to help teach the course and should have one of these extensions: .pdf, .doc, .docx, .odt, .xls, .xlsx) *</label>
       <br />
       <label style="font-style: italic;">You can either drag and drop your file or click on the "Upload File" box below</label>
       <div class="uploadable">
-        <input id="projectFile" name="projectFile" type="file" class="required" />
+        <input id="projectFile" name="projectFile" type="file" accept=".pdf,.doc,.docx,.odt,.xls,.xlsx" class="required" />
         <label id="projectFileLabel" for="projectFile"><i class="fa fa-upload"></i><br />Upload File</label>
       </div>
     </section>


### PR DESCRIPTION
1. Make sure project prep time and project length filters show up
2. Update handling of date posted so it shows up properly
3. Make sure we link to the pdf version of the uploaded project for filename
4. Restrict image upload to `image/*` file types
5. Restrict content to ones I could verify work after QA-ing a bunch of types (`.pdf, .doc, .docx, .odt, .xls, .xlsx`)

