### PR TITLE
add rudimentary browser support check

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,4 +15,19 @@
   <script src="{{site.baseurl}}/assets/js/jquery-1.12.4.js"></script>
   <script type="text/javascript" src="{{site.baseurl}}/assets/js/bootstrap.js"></script>
 
+  <script>
+    var supportsES6 = function() {
+      try {
+        new Function("(a = 0) => a");
+        return true;
+      }
+      catch (err) {
+        return false;
+      }
+    }();
+
+    if (!supportsES6) {
+      alert('Some features on this site are not supported by your browser. We recommend updating your browser or using a different browser for the best possible experience.');
+    }
+  </script>
 </head>


### PR DESCRIPTION
Really basic browser support check - shows an alert if we know for sure the user's browser doesn't support es6.

The problem is that we have a bunch of es6 features and would need to introduce webpack otherwise to handle all cases. Easiest solution is to just prompt users to upgrade their browser (since the vast majority of users will already have a browser with es6 support)